### PR TITLE
클라이언트 피드백을 기반으로 음료 목록 조회, 음료 검색 API Spec 변경

### DIFF
--- a/src/main/java/be/ddd/api/cafe/CafeBeverageAPI.java
+++ b/src/main/java/be/ddd/api/cafe/CafeBeverageAPI.java
@@ -81,17 +81,22 @@ public class CafeBeverageAPI {
 
     @GetMapping("/search")
     public ApiResponse<BeverageSearchResultDto> searchBeverages(
-            @RequestParam(required = false) String keyword) {
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String sugarLevel,
+            @RequestParam(required = false) Boolean onlyLiked) {
 
         String targetKeyword = (keyword == null ? "" : keyword).trim();
 
         if (!StringUtils.hasText(targetKeyword)) {
             log.info("Empty keyword");
-            return ApiResponse.success(new BeverageSearchResultDto(List.of(), 0));
+            return ApiResponse.success(new BeverageSearchResultDto(List.of(), 0, 0, 0, 0));
         }
 
+        Optional<SugarLevel> sugar = SugarLevel.fromParam(sugarLevel);
+
         BeverageSearchResultDto beverageSearchResultDto =
-                cafeBeverageQueryService.searchBeverages(targetKeyword, MEMBER_ID);
+                cafeBeverageQueryService.searchBeverages(
+                        targetKeyword, MEMBER_ID, sugar, onlyLiked);
         return ApiResponse.success(beverageSearchResultDto);
     }
 }

--- a/src/main/java/be/ddd/api/dto/res/BeverageSearchResultDto.java
+++ b/src/main/java/be/ddd/api/dto/res/BeverageSearchResultDto.java
@@ -4,4 +4,8 @@ import be.ddd.application.beverage.dto.BeverageSearchDto;
 import java.util.List;
 
 public record BeverageSearchResultDto(
-        List<BeverageSearchDto> beverageSearchResults, long likeCount) {}
+        List<BeverageSearchDto> beverageSearchResults,
+        long likeCount,
+        long totalCount,
+        long zeroSugarCount,
+        long lowSugarCount) {}

--- a/src/main/java/be/ddd/application/beverage/BeverageQueryPredicates.java
+++ b/src/main/java/be/ddd/application/beverage/BeverageQueryPredicates.java
@@ -1,0 +1,55 @@
+package be.ddd.application.beverage;
+
+import be.ddd.domain.entity.crawling.CafeBrand;
+import be.ddd.domain.entity.crawling.QCafeBeverage;
+import be.ddd.domain.entity.crawling.SugarLevel;
+import be.ddd.domain.entity.member.QMemberBeverageLike;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import jakarta.annotation.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class BeverageQueryPredicates {
+
+    private final QCafeBeverage beverage = QCafeBeverage.cafeBeverage;
+    private final QMemberBeverageLike memberBeverageLike = QMemberBeverageLike.memberBeverageLike;
+
+    public BooleanExpression brandEq(@Nullable CafeBrand brand) {
+        return brand != null ? beverage.cafeStore.cafeBrand.eq(brand) : null;
+    }
+
+    public BooleanExpression sugarLevelEq(@Nullable SugarLevel sugarLevel) {
+        if (sugarLevel == null) {
+            return null;
+        }
+        if (sugarLevel == SugarLevel.ZERO) {
+            return beverage.sizes.any().beverageNutrition.sugarG.eq(0);
+        }
+        if (sugarLevel == SugarLevel.LOW) {
+            return beverage.sizes.any().beverageNutrition.sugarG.between(1, 20);
+        }
+        return null;
+    }
+
+    public BooleanExpression onlyLiked(@Nullable Boolean onlyLiked) {
+        if (onlyLiked == null || !onlyLiked) {
+            return null;
+        }
+        return memberBeverageLike.isNotNull();
+    }
+
+    public BooleanExpression keywordSearch(String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return null;
+        }
+        String booleanWildcard = "+" + keyword.trim() + "*";
+        return Expressions.numberTemplate(
+                        Double.class,
+                        "fulltext_match({0}, {1})",
+                        beverage.name,
+                        Expressions.constant(booleanWildcard))
+                .gt(0);
+    }
+}

--- a/src/main/java/be/ddd/application/beverage/CafeBeverageQueryService.java
+++ b/src/main/java/be/ddd/application/beverage/CafeBeverageQueryService.java
@@ -23,5 +23,6 @@ public interface CafeBeverageQueryService {
 
     BeverageCountDto getBeverageCountByBrandAndSugarLevel(Optional<CafeBrand> brandFilter);
 
-    BeverageSearchResultDto searchBeverages(String keyword, Long memberId);
+    BeverageSearchResultDto searchBeverages(
+            String keyword, Long memberId, Optional<SugarLevel> sugarLevel, Boolean onlyLiked);
 }

--- a/src/main/java/be/ddd/application/beverage/CafeBeverageQueryServiceImpl.java
+++ b/src/main/java/be/ddd/application/beverage/CafeBeverageQueryServiceImpl.java
@@ -110,10 +110,21 @@ public class CafeBeverageQueryServiceImpl implements CafeBeverageQueryService {
     }
 
     @Override
-    public BeverageSearchResultDto searchBeverages(String keyword, Long memberId) {
+    public BeverageSearchResultDto searchBeverages(
+            String keyword, Long memberId, Optional<SugarLevel> sugarLevel, Boolean onlyLiked) {
         List<BeverageSearchDto> beverageSearchResults =
-                beverageRepository.searchByName(keyword, memberId);
+                beverageRepository.searchByName(keyword, memberId, sugarLevel, onlyLiked);
         long likeCount = beverageSearchResults.stream().filter(BeverageSearchDto::isLiked).count();
-        return new BeverageSearchResultDto(beverageSearchResults, likeCount);
+
+        BeverageCountDto counts =
+                beverageRepository.countSugarLevelBySearchFilters(
+                        keyword, memberId, sugarLevel, onlyLiked);
+
+        return new BeverageSearchResultDto(
+                beverageSearchResults,
+                likeCount,
+                counts.totalCount(),
+                counts.zeroCount(),
+                counts.lowCount());
     }
 }

--- a/src/main/java/be/ddd/domain/repo/CafeBeverageRepositoryCustom.java
+++ b/src/main/java/be/ddd/domain/repo/CafeBeverageRepositoryCustom.java
@@ -7,6 +7,7 @@ import be.ddd.domain.entity.crawling.CafeBrand;
 import be.ddd.domain.entity.crawling.SugarLevel;
 import jakarta.annotation.Nullable;
 import java.util.List;
+import java.util.Optional;
 
 public interface CafeBeverageRepositoryCustom {
     List<CafeBeveragePageDto> findWithCursor(
@@ -19,8 +20,12 @@ public interface CafeBeverageRepositoryCustom {
 
     BeverageCountDto countSugarLevelByBrand(@Nullable CafeBrand brandFilter);
 
-    List<BeverageSearchDto> searchByName(String keyword, Long memberId);
+    List<BeverageSearchDto> searchByName(
+            String keyword, Long memberId, Optional<SugarLevel> sugarLevel, Boolean onlyLiked);
 
     long countAllLikedByMemberAndFilters(
             @Nullable CafeBrand brand, @Nullable SugarLevel sugarLevel, Long memberId);
+
+    BeverageCountDto countSugarLevelBySearchFilters(
+            String keyword, Long memberId, Optional<SugarLevel> sugarLevel, Boolean onlyLiked);
 }


### PR DESCRIPTION
> Closes #{이슈_번호}

## PR 타입 (하나 이상의 PR 타입 선택)
- [ ] 기능 추가
- [X] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 설정 변경 (Config Class)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 배포환경
- [ ] 문서 수정 (ex. README)

## 반영 사항
- 음료 목록조회에서 당류별 조회시에도  전체 좋아요 개수가 나와야한다.(page 영향안받고 전체로 나오도록)

- 검색 api에서 검색된 결과에 한해서 전체, 무당, 저당 개수를 client에게 전달되도록

- 검색 API에서도 전체,무당, 저당(sugarLevel) 필터링 및  찜한 음료(onlyLiked) 에대해서 필터링 가능하도록

- 음료 목록조회와 검색에서 중복되는 쿼리를 Predicates 클래스를 통해 해결
## 유의 사항

## 참여자
- @seonghoo1217 