### PR TITLE
FCM 알림 KST 보장하도록 수정

### DIFF
--- a/src/main/java/be/ddd/application/notification/NotificationSchedulingService.java
+++ b/src/main/java/be/ddd/application/notification/NotificationSchedulingService.java
@@ -1,12 +1,12 @@
 package be.ddd.application.notification;
 
 import be.ddd.application.discord.DiscordNotificationService;
-import be.ddd.common.util.CustomClock;
+import be.ddd.common.util.KoreanTimeService;
 import be.ddd.domain.entity.member.Member;
 import be.ddd.domain.repo.IntakeHistoryRepository;
 import be.ddd.domain.repo.MemberRepository;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -27,12 +27,14 @@ public class NotificationSchedulingService {
     private final IntakeHistoryRepository intakeHistoryRepository;
     private final FCMService fcmService;
     private final DiscordNotificationService discordNotificationService;
+    private final KoreanTimeService koreanTimeService;
 
     @Async
     @Scheduled(cron = "0 * * * * *")
     public void sendSugarIntakeNotifications() {
-        LocalTime now = CustomClock.now().toLocalTime();
-        log.info("[NotificationTest] 1. Current fake time: {}", now);
+        ZonedDateTime koreaNow = koreanTimeService.now();
+        LocalTime now = koreaNow.toLocalTime();
+        log.info("[NotificationTest] 1. Current KST time: {}", koreaNow);
 
         List<Member> members = memberRepository.findAllByNotificationEnabledAndReminderTime(now);
         log.info(
@@ -49,7 +51,8 @@ public class NotificationSchedulingService {
                 members.stream().map(Member::getProviderId).collect(Collectors.toList());
 
         Map<Long, Double> totalSugars =
-                intakeHistoryRepository.sumSugarByMemberIdsAndDate(memberIds, LocalDateTime.now());
+                intakeHistoryRepository.sumSugarByMemberIdsAndDate(
+                        memberIds, koreaNow.toLocalDateTime());
         log.info(
                 "[NotificationTest] 3. Found sugar intake data for {} members.",
                 totalSugars.size());

--- a/src/main/java/be/ddd/common/util/KoreanTimeService.java
+++ b/src/main/java/be/ddd/common/util/KoreanTimeService.java
@@ -1,0 +1,36 @@
+package be.ddd.common.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.springframework.stereotype.Component;
+
+/**
+ * Provides the current time in Korean Standard Time (Asia/Seoul).
+ *
+ * <p>This service wraps {@link CustomClock} so tests that fix the clock keep working while giving
+ * callers stable {@link ZoneId} aware timestamps.
+ */
+@Component
+public class KoreanTimeService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    public ZonedDateTime now() {
+        return CustomClock.now().atZone(KST);
+    }
+
+    public LocalDateTime currentDateTime() {
+        return now().toLocalDateTime();
+    }
+
+    public LocalDate currentDate() {
+        return now().toLocalDate();
+    }
+
+    public LocalTime currentTime() {
+        return now().toLocalTime();
+    }
+}


### PR DESCRIPTION
> Closes #88

## PR 타입 (하나 이상의 PR 타입 선택)
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 설정 변경 (Config Class)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 배포환경
- [ ] 문서 수정 (ex. README)

## 반영 사항
- 기존 알림 발송 로직에서 UTC기준을 사용하던 부분을 `KoreanTimeService` 도입하여 KST 시간대 보장
## 유의 사항

## 참여자
- @seonghoo1217 